### PR TITLE
Refactor init to await authentication

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/koa-gu",
-  "version": "1.0.1-0",
+  "version": "1.0.1-1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/koa-gu",
-      "version": "1.0.1-0",
+      "version": "1.0.1-1",
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1.35",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@guardian/koa-gu",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@guardian/koa-gu",
-      "version": "0.0.2",
+      "version": "1.0.1-0",
       "license": "ISC",
       "dependencies": {
         "aws-sdk": "^2.1.35",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/koa-gu",
-  "version": "1.0.0",
+  "version": "1.0.1-0",
   "description": "some small reusable modules for guardian koa micro-sites; this is a Guardian version of koa-gu",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guardian/koa-gu",
-  "version": "1.0.1-0",
+  "version": "1.0.1-1",
   "description": "some small reusable modules for guardian koa micro-sites; this is a Guardian version of koa-gu",
   "main": "index.js",
   "scripts": {

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,0 +1,25 @@
+var AWS = require("aws-sdk");
+
+module.exports = async function({ aws_profile }) {
+  console.log({aws_profile});
+  AWS.CredentialProviderChain.defaultProviders = [
+    function () {
+      return new AWS.EC2MetadataCredentials();
+    },
+    function () {
+      return new AWS.SharedIniFileCredentials({
+        profile: aws_profile ? aws_profile : "interactives",
+      });
+    },
+  ];
+
+  var chain = new AWS.CredentialProviderChain();
+
+  try {
+    const credentials = await chain.resolvePromise();
+    AWS.config.credentials = credentials;
+    return credentials;
+  } catch(e) {
+    console.log("Error authenticating AWS credentials: " + e.message);
+  }
+}

--- a/src/auth.js
+++ b/src/auth.js
@@ -1,7 +1,6 @@
 var AWS = require("aws-sdk");
 
 module.exports = async function({ aws_profile }) {
-  console.log({aws_profile});
   AWS.CredentialProviderChain.defaultProviders = [
     function () {
       return new AWS.EC2MetadataCredentials();

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,7 @@ function createLogger(logdir) {
 }
 
 var gu = {
-    init: function(_opts) {
+    init: async function(_opts) {
         const opts = _opts || {};
         const www = opts.www !== undefined ? opts.www : true;
         const db = opts.db !== undefined ? opts.db : true;
@@ -84,6 +84,9 @@ var gu = {
         var callerDir = path.dirname(callsite()[1].getFileName());
 
         gu.config = loadMainConfig(callerDir);
+
+        const credentials = await require('./auth')(gu.config);
+
         if (www) {
             gu.router = gu.config.routes ? require('./router')(gu.config) : null;
             gu.static = gu.config.static ? require('./static')(gu.config) : null;
@@ -92,7 +95,7 @@ var gu = {
 
         if (db) gu.db = require('./db')
 
-        gu.s3 = require('./s3')(gu.config)
+        gu.s3 = require('./s3')()
         gu.tmpl = require('./tmpl')(gu.config)
 
         gu.dir = function() {

--- a/src/s3.js
+++ b/src/s3.js
@@ -1,31 +1,7 @@
 var AWS = require("aws-sdk");
 var denodeify = require("denodeify");
 
-module.exports = async function (cfg) {
-  AWS.CredentialProviderChain.defaultProviders = [
-    function () {
-      return new AWS.EC2MetadataCredentials();
-    },
-    function () {
-      return new AWS.SharedIniFileCredentials({
-        profile: cfg.aws_profile ? cfg.aws_profile : "default",
-      });
-    },
-  ];
-
-  var chain = new AWS.CredentialProviderChain();
-
-  var chainpromise = chain.resolvePromise();
-
-  chainpromise.then(
-    function (credentials) {
-      AWS.config.credentials = credentials;
-    },
-    function (err) {
-      console.log("Error: " + err.message);
-    }
-  );
-
+module.exports = function () {
   var s3 = new AWS.S3();
 
   const exportFns = {};


### PR DESCRIPTION
## What does this change?

Refactors the `init` function to await successful authentication. Previously, auth depended on static credentials that could be synchronously acquired – now, in PROD, we use EC2 metadata auth, which is asynchronous.

## How to test

Consume this library in a running application, remembering to `await` the call to `gu.init()`. Does the application work as expected?

- [x] Tested in PROD.